### PR TITLE
Add ability to override check button

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -225,20 +225,21 @@ H5P.QuestionSet = function (options, contentId, contentData) {
   var $template = $(template.render(params));
 
   // Set overrides for questions
-  var override;
-  if (params.override.showSolutionButton || params.override.retryButton) {
-    override = {};
-    if (params.override.showSolutionButton) {
-      // Force "Show solution" button to be on or off for all interactions
-      override.enableSolutionsButton =
-          (params.override.showSolutionButton === 'on' ? true : false);
-    }
+  var override = {};
 
-    if (params.override.retryButton) {
-      // Force "Retry" button to be on or off for all interactions
-      override.enableRetry =
-          (params.override.retryButton === 'on' ? true : false);
-    }
+  if (params.override.checkButton) {
+    // Force "Check" button to be on or off for all interactions
+    override.enableCheck = params.override.checkButton === 'on';
+  }
+
+  if (params.override.showSolutionButton) {
+    // Force "Show solution" button to be on or off for all interactions
+    override.enableSolutionsButton = params.override.showSolutionButton === 'on';
+  }
+
+  if (params.override.retryButton) {
+    // Force "Retry" button to be on or off for all interactions
+    override.enableRetry = params.override.retryButton === 'on';
   }
 
   /**

--- a/library.json
+++ b/library.json
@@ -4,7 +4,7 @@
   "contentType": "question",
   "majorVersion": 1,
   "minorVersion": 13,
-  "patchVersion": 0,
+  "patchVersion": 1,
   "embedTypes": [
     "iframe"
   ],

--- a/semantics.json
+++ b/semantics.json
@@ -418,10 +418,28 @@
   {
     "name": "override",
     "type": "group",
-    "label": "Settings for \"Show solution\" and \"Retry\" buttons",
+    "label": "Override settings for \"Check\", \"Show solution\" and \"Retry\" buttons",
     "importance": "low",
     "optional": true,
     "fields": [
+      {
+        "name": "checkButton",
+        "type": "select",
+        "label": "Override \"Check\" button",
+        "importance": "low",
+        "description": "This option determines if the \"Check\" button will be shown for all questions, disabled for all or configured for each question individually.",
+        "optional": true,
+        "options": [
+          {
+            "value": "on",
+            "label": "Enabled"
+          },
+          {
+            "value": "off",
+            "label": "Disabled"
+          }
+        ]
+      },
       {
         "name": "showSolutionButton",
         "type": "select",


### PR DESCRIPTION
@icc add ability to configure check button for question-set, also please review following pull requests for question set subtypes: [H5P.MultiChoice](https://github.com/h5p/h5p-multi-choice/pull/26), [H5P.DragQuestion](https://github.com/h5p/h5p-drag-question/pull/21), [H5P.Blanks](https://github.com/h5p/h5p-blanks/pull/15), [H5P.MarkTheWords](https://github.com/h5p/h5p-mark-the-words/pull/9), [H5P.DragText](https://github.com/h5p/h5p-drag-text/pull/16), [H5P.TrueFalse](https://github.com/h5p/h5p-true-false/pull/7)


