### PR TITLE
HFP-2782 Correct typo in semantics and translation files

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/af.json
+++ b/language/af.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/ca.json
+++ b/language/ca.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/cs.json
+++ b/language/cs.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/da.json
+++ b/language/da.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/el.json
+++ b/language/el.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/es.json
+++ b/language/es.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/fa.json
+++ b/language/fa.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/hu.json
+++ b/language/hu.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/ko.json
+++ b/language/ko.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/ro.json
+++ b/language/ro.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/sr.json
+++ b/language/sr.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/tr.json
+++ b/language/tr.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/language/vi.json
+++ b/language/vi.json
@@ -220,7 +220,7 @@
         },
         {
           "label": "Fail video",
-          "description": "This video will be played if the user failes the quiz."
+          "description": "This video will be played if the user fails the quiz."
         }
       ]
     },

--- a/semantics.json
+++ b/semantics.json
@@ -469,7 +469,7 @@
         "label": "Fail video",
         "importance": "low",
         "optional": true,
-        "description": "This video will be played if the user failes the quiz."
+        "description": "This video will be played if the user fails the quiz."
       }
     ]
   },


### PR DESCRIPTION
Correct "if the user failes" to "if the user fails" as described in https://h5ptechnology.atlassian.net/browse/HFP-2782