### PR TITLE
Fix intro image scaling if used in compound content types

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -946,11 +946,14 @@ H5P.QuestionSet = function (options, contentId, contentData) {
       if ($intro.length) {
         var bgImg = params.introPage.backgroundImage;
         var bgImgRatio = (bgImg.height / bgImg.width);
-        $intro.css({
-          background: '#fff url("' + H5P.getPath(bgImg.path, contentId) + '") no-repeat 50% 50%',
-          backgroundSize: 'auto 100%',
-          minHeight: bgImgRatio * +window.getComputedStyle($intro[0]).width.replace('px','')
-        });
+
+        setTimeout(function () {
+          $intro.css({
+            background: '#fff url("' + H5P.getPath(bgImg.path, contentId) + '") no-repeat 50% 50%',
+            backgroundSize: 'auto 100%',
+            minHeight: bgImgRatio * +window.getComputedStyle($intro[0]).width.replace('px','')
+          });
+        }, 0);
       }
     }
 


### PR DESCRIPTION
When using QS in compount content types (in Column in particular),
the intro div may not have been rendered when determining its
width. In consequence, instead of scaling the intro image to full
width, it would be displayed in its natural dimensions in Column.

This pull request fixes this behavior and the intro image will scale
properly in Column as well.