### PR TITLE
Fix showing progress in solution mode

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -456,6 +456,7 @@ H5P.QuestionSet = function (options, contentId, contentData) {
     for (var i = 0; i < questionInstances.length; i++) {
 
       // Enable back and forth navigation in solution mode
+      toggleAnsweredDot(i, questionInstances[i].getAnswerGiven());
       toggleDotsNavigation(true);
       if (i < questionInstances.length - 1) {
         questionInstances[i].showButton('next');


### PR DESCRIPTION
When merged in, the changes fix the outer right progress dot not bearing the answered state when switching to solution mode. See report at https://github.com/h5p/h5p-question-set/issues/71