### PR TITLE
VA-987 Fix child title on ResultScreen

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -778,8 +778,8 @@ H5P.QuestionSet = function (options, contentId, contentData) {
           .replace('@finals', `<span>${finals}</span>`).replace('@totals', `<span>${totals}</span>`),
         questionGroups: [{
           listHeaders: [params.texts.questionLabel, params.endGame.scoreHeader],
-          questions: questionInstances.map((question) => ({
-            title: question.contentData?.metadata.title ?? '',
+          questions: questionInstances.map((question, index) => ({
+            title: params.questions[index]?.metadata.title ?? '',
             points: `${question.getScore()}/${question.getMaxScore()}`,
           })),
         }],


### PR DESCRIPTION
When merged in, will properly query the child's metadata for the title on the ResultScreen.