### PR TITLE
VA-1223 Set current index to 0 on showSolutions

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -480,6 +480,8 @@ H5P.QuestionSet = function (options, contentId, contentData) {
         H5P.error(error);
       }
     }
+
+    nav.setCurrentIndex(0);
   };
 
   /**


### PR DESCRIPTION
When merged in, will ensure that navigation bar progress is set to proper position on `showSolutions`.