### PR TITLE
Add GuessTheAnswer to QuestionSet whitelist

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -130,7 +130,8 @@
         "H5P.DragText 1.10",
         "H5P.TrueFalse 1.8",
         "H5P.Essay 1.5",
-        "H5P.MultiMediaChoice 0.3"
+        "H5P.MultiMediaChoice 0.3",
+        "H5P.GuessTheAnswer 1.5"
       ]
     }
   },


### PR DESCRIPTION
## Summary

Add `GuessTheAnswer` to the QuestionSet whitelist in `library.json`.

## Reason

This allows `GuessTheAnswer` to be used as a valid subcontent type inside QuestionSet.

Without this change, the content type cannot be selected or executed within QuestionSet.

## Related PR

This change depends on the refactored `GuessTheAnswer` implementation: https://github.com/h5p/h5p-guess-the-answer/pull/55

Both PRs belong together and should be merged in coordination.
