### PR TITLE
Fix missing overall feedback and score bar on result screen

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -688,16 +688,18 @@ H5P.QuestionSet = function (options, contentId, contentData) {
         });
       }
 
-      // Restore feedback-section wrapper removed in VA-460 so the
-      // overall feedback text and score bar have a place to render.
-      $('<div>', {
-        class: 'feedback-section',
-        append: [
-          $('<div>', { class: 'feedback-scorebar' }),
-          $('<div>', { class: 'feedback-text' })
-        ],
-        appendTo: self.$resultPage
-      });
+      var feedbackSection = document.createElement('div');
+      feedbackSection.className = 'feedback-section';
+
+      var feedbackScorebar = document.createElement('div');
+      feedbackScorebar.className = 'feedback-scorebar';
+      feedbackSection.appendChild(feedbackScorebar);
+
+      var feedbackText = document.createElement('div');
+      feedbackText.className = 'feedback-text';
+      feedbackSection.appendChild(feedbackText);
+
+      self.$resultPage.append(feedbackSection);
 
       self.$buttonsContainer = $('<div>', {
         class: 'buttons',

--- a/js/questionset.js
+++ b/js/questionset.js
@@ -688,14 +688,14 @@ H5P.QuestionSet = function (options, contentId, contentData) {
         });
       }
 
-      var feedbackSection = document.createElement('div');
+      const feedbackSection = document.createElement('div');
       feedbackSection.className = 'feedback-section';
 
-      var feedbackScorebar = document.createElement('div');
+      const feedbackScorebar = document.createElement('div');
       feedbackScorebar.className = 'feedback-scorebar';
       feedbackSection.appendChild(feedbackScorebar);
 
-      var feedbackText = document.createElement('div');
+      const feedbackText = document.createElement('div');
       feedbackText.className = 'feedback-text';
       feedbackSection.appendChild(feedbackText);
 

--- a/js/questionset.js
+++ b/js/questionset.js
@@ -688,6 +688,15 @@ H5P.QuestionSet = function (options, contentId, contentData) {
         });
       }
 
+      // Restore feedback-section wrapper removed in VA-460 so the
+      // overall feedback text and score bar have a place to render.
+      self.$feedbackSection = $(
+        '<div class="feedback-section">' +
+          '<div class="feedback-scorebar"></div>' +
+          '<div class="feedback-text"></div>' +
+        '</div>'
+      ).appendTo(self.$resultPage);
+
       self.$buttonsContainer = $('<div>', {
         class: 'buttons',
         appendTo: self.$resultPage

--- a/js/questionset.js
+++ b/js/questionset.js
@@ -690,12 +690,14 @@ H5P.QuestionSet = function (options, contentId, contentData) {
 
       // Restore feedback-section wrapper removed in VA-460 so the
       // overall feedback text and score bar have a place to render.
-      self.$feedbackSection = $(
-        '<div class="feedback-section">' +
-          '<div class="feedback-scorebar"></div>' +
-          '<div class="feedback-text"></div>' +
-        '</div>'
-      ).appendTo(self.$resultPage);
+      $('<div>', {
+        class: 'feedback-section',
+        append: [
+          $('<div>', { class: 'feedback-scorebar' }),
+          $('<div>', { class: 'feedback-text' })
+        ],
+        appendTo: self.$resultPage
+      });
 
       self.$buttonsContainer = $('<div>', {
         class: 'buttons',


### PR DESCRIPTION
## Summary

- Result screen stopped rendering the **Overall Feedback** text and the **score bar** after the `H5P.Components.ResultScreen` refactor (VA-460, 2c3e287).
- The refactor removed the `.feedback-section` / `.feedback-scorebar` / `.feedback-text` wrapper, but `_displayEndGame` still tries to fill those selectors via jQuery — both matched zero elements, so the computed `scoreString` and score bar were silently dropped.
- This PR re-adds the wrapper inside the result page so the existing append logic has real targets again. No other code paths or styles change.

Fixes #183

## Test plan

- [ ] Create a Question Set with 2+ questions and configure `Overall Feedback` ranges (e.g. 0–49% "Try again", 50–100% "Well done").
- [ ] Leave *Display results* enabled, complete the quiz, confirm score bar and matching overall feedback text appear on the result screen.
- [ ] Turn *Display results* off, confirm feedback section and buttons are hidden (the existing `else` branch at `js/questionset.js:748` now actually removes `.feedback-section`).
- [ ] Per-question list, headers and score summary still render as before.