### PR TITLE
Fix current question text not passed to navigation component

### DIFF
--- a/js/questionset.js
+++ b/js/questionset.js
@@ -342,6 +342,7 @@ H5P.QuestionSet = function (options, contentId, contentData) {
     answeredText: params.texts.answeredText,
     unansweredText: params.texts.unansweredText,
     textualProgress: params.texts.textualProgress,
+    currentQuestionText: params.texts.currentQuestionText,
   }
   // If backwards navigation is disabled, we show textual progress instead
   if (params.progressType == "dots" && !params.disableBackwardsNavigation) {

--- a/js/questionset.js
+++ b/js/questionset.js
@@ -345,7 +345,7 @@ H5P.QuestionSet = function (options, contentId, contentData) {
     currentQuestionText: params.texts.currentQuestionText,
   }
   // If backwards navigation is disabled, we show textual progress instead
-  if (params.progressType == "dots" && !params.disableBackwardsNavigation) {
+  if (params.progressType === "dots" && !params.disableBackwardsNavigation) {
     nav = H5P.Components.Navigation({
       className: 'qs-footer',
       handlePrevious: () => this.moveQuestion(-1),


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix 1: The aria label text to be assigned to the navigation bar's progress dot (`currentQuestionText`) is now passed to the navigation component.

Bug fix 2: The comparison for the progress type now uses the correct comparator `===` following the coding style guidelines.

**What is the current behaviour?**
When the progress dot of H5P.Components.ProgressDots tries to set the `currentQuestionText` on its ARIA label, it prints `undefined`, because it never received that text from H5P.Components.Navigation, because that in turn never received it from H5P.QuestionSet.

**What is the new behaviour?**
The aria label text to be assigned to the navigation bar's progress dot (`currentQuestionText`) is now passed to the navigation component and thus to the progress dot.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
